### PR TITLE
Fixed router not returning headers

### DIFF
--- a/context.go
+++ b/context.go
@@ -27,6 +27,15 @@ type Context struct {
 	handlers []Handler              // the handlers associated with the current route
 }
 
+var defaultContentType = []byte("text/plain; charset=utf-8")
+// Error sets response status code to the given value and sets response body
+// to the given message.
+func (c *Context) ErrorWithHeaders(msg string, statusCode int) {
+	c.SetStatusCode(statusCode)
+	c.SetContentTypeBytes(defaultContentType)
+	c.SetBodyString(msg)
+}
+
 // Router returns the Router that is handling the incoming HTTP request.
 func (c *Context) Router() *Router {
 	return c.router

--- a/router.go
+++ b/router.go
@@ -100,9 +100,9 @@ func (r *Router) NotFound(handlers ...Handler) {
 // handleError is the error handler for handling any unhandled errors.
 func (r *Router) handleError(c *Context, err error) {
 	if httpError, ok := err.(HTTPError); ok {
-		c.Error(httpError.Error(), httpError.StatusCode())
+		c.ErrorWithHeaders(httpError.Error(), httpError.StatusCode())
 	} else {
-		c.Error(err.Error(), http.StatusInternalServerError)
+		c.ErrorWithHeaders(err.Error(), http.StatusInternalServerError)
 	}
 }
 


### PR DESCRIPTION
Due to using fasthttp builtin error function which resets the context, no headers were written in the response. This fix introduces new function which does not reset context so all headers are written.